### PR TITLE
WIP: Adapting the cfssl download to work also with the other architectures and improving the travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,10 @@ before_script:
 
 script:
   - make build-nocache NAME=${NAME} VERSION=${VERSION}-${TARGET_ARCH}
-
-after_success:
+  # Run the test and if the test fails mark the build as failed.
   - make test NAME=${NAME} VERSION=${VERSION}-${TARGET_ARCH}
+
+before_deploy:
   - docker run -d --name test_image ${NAME}:${VERSION}-${TARGET_ARCH} sleep 10
   - sleep 5
   - sudo docker ps | grep -q test_image
@@ -74,28 +75,49 @@ after_success:
   # use `travis env set`.
   - docker login -u "$DOCKER_USER" -p "$DOCKER_PASS";
   - make tag NAME=${NAME} VERSION=${VERSION}-${TARGET_ARCH}
-  - make push NAME=${NAME} VERSION=${VERSION}-${TARGET_ARCH}
+
+deploy:
+  provider: script
+  on:
+    repo: osixia/docker-light-baseimage
+    all_branches: true
+  script: make push NAME=${NAME} VERSION=${VERSION}-${TARGET_ARCH}
 
 jobs:
   include:
-    - stage: deploy
+    - stage: Manifest creation
       install: skip
       script: skip
-      after_success:
+      after_deploy:
         - docker login -u "$DOCKER_USER" -p "$DOCKER_PASS";
-        - docker manifest create ${NAME}:${VERSION} ${NAME}:${VERSION}-amd64 ${NAME}:${VERSION}-i386 ${NAME}:${VERSION}-arm32v7 ${NAME}:${VERSION}-arm64v8;
-          docker manifest annotate ${NAME}:${VERSION} ${NAME}:${VERSION}-amd64 --os linux --arch amd64;
-          docker manifest annotate ${NAME}:${VERSION} ${NAME}:${VERSION}-i386 --os linux --arch 386;
-          docker manifest annotate ${NAME}:${VERSION} ${NAME}:${VERSION}-arm32v7 --os linux --arch arm --variant v7;
-          docker manifest annotate ${NAME}:${VERSION} ${NAME}:${VERSION}-arm64v8 --os linux --arch arm64 --variant v8;
+        - docker manifest create ${NAME}:${VERSION} 
+            ${NAME}:${VERSION}-amd64 ${NAME}:${VERSION}-i386 
+            ${NAME}:${VERSION}-arm32v7 
+            ${NAME}:${VERSION}-arm64v8;
+          docker manifest annotate ${NAME}:${VERSION} 
+            ${NAME}:${VERSION}-amd64 --os linux --arch amd64;
+          docker manifest annotate ${NAME}:${VERSION} 
+            ${NAME}:${VERSION}-i386 --os linux --arch 386;
+          docker manifest annotate ${NAME}:${VERSION} 
+            ${NAME}:${VERSION}-arm32v7 --os linux --arch arm --variant v7;
+          docker manifest annotate ${NAME}:${VERSION} 
+            ${NAME}:${VERSION}-arm64v8 --os linux --arch arm64 --variant v8;
 
         # The latest tag is coming from the stable branch of the repo
         - if [ "${TRAVIS_BRANCH}" == 'stable' ]; then
-            docker manifest create ${NAME}:latest ${NAME}:${VERSION}-amd64 ${NAME}:${VERSION}-i386 ${NAME}:${VERSION}-arm32v7 ${NAME}:${VERSION}-arm64v8;
-            docker manifest annotate ${NAME}:latest ${NAME}:${VERSION}-amd64 --os linux --arch amd64;
-            docker manifest annotate ${NAME}:latest ${NAME}:${VERSION}-i386 --os linux --arch 386;
-            docker manifest annotate ${NAME}:latest ${NAME}:${VERSION}-arm32v7 --os linux --arch arm --variant v7;
-            docker manifest annotate ${NAME}:latest ${NAME}:${VERSION}-arm64v8 --os linux --arch arm64 --variant v8;
+            docker manifest create ${NAME}:latest 
+              ${NAME}:${VERSION}-amd64 
+              ${NAME}:${VERSION}-i386 
+              ${NAME}:${VERSION}-arm32v7 
+              ${NAME}:${VERSION}-arm64v8;
+            docker manifest annotate ${NAME}:latest 
+              ${NAME}:${VERSION}-amd64 --os linux --arch amd64;
+            docker manifest annotate ${NAME}:latest 
+              ${NAME}:${VERSION}-i386 --os linux --arch 386;
+            docker manifest annotate ${NAME}:latest 
+              ${NAME}:${VERSION}-arm32v7 --os linux --arch arm --variant v7;
+            docker manifest annotate ${NAME}:latest 
+              ${NAME}:${VERSION}-arm64v8 --os linux --arch arm64 --variant v8;
           fi
 
         - docker manifest push ${NAME}:${VERSION};

--- a/image/.dockerignore
+++ b/image/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.gitignore
+.gitattributes
+.travis.yml
+Makefile
+LICENSE
+CHANGELOG.md
+README.md

--- a/image/service-available/:ssl-tools/download.sh
+++ b/image/service-available/:ssl-tools/download.sh
@@ -1,14 +1,42 @@
 #!/bin/bash -e
 
+case $( dpkg --print-architecture ) in
+
+    "amd64")
+    HOST_ARCH="amd64"
+    ;;
+
+    "arm64")
+    HOST_ARCH="arm64"
+    ;;
+
+    "arm" | "armhf")
+    HOST_ARCH="arm"
+    ;;
+
+    "i386")
+    HOST_ARCH="386"
+    ;;
+
+    *)
+    echo "Unkown architecture. Exiting."
+    exit 1
+    ;;
+esac
+
+echo "The architecture is ${HOST_ARCH}"
+
 # download curl and ca-certificate from apt-get if needed
 to_install=()
 
 if [ "$(dpkg-query -W -f='${Status}' curl 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
     to_install+=("curl")
+    echo "Installing curl."
 fi
 
 if [ "$(dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
     to_install+=("ca-certificates")
+    echo "Installing ca-certificates."
 fi
 
 if [ ${#to_install[@]} -ne 0 ]; then
@@ -18,11 +46,13 @@ fi
 LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssl jq
 
 echo "Download cfssl ..."
-curl -o /usr/sbin/cfssl -SL https://github.com/osixia/cfssl/releases/download/1.3.4/cfssl_linux-amd64
+echo "curl -o /usr/sbin/cfssl -SL https://github.com/osixia/cfssl/releases/download/1.3.4/cfssl_linux-${HOST_ARCH}"
+eval curl -o /usr/sbin/cfssl -SL https://github.com/osixia/cfssl/releases/download/1.3.4/cfssl_linux-"${HOST_ARCH}"
 chmod 700 /usr/sbin/cfssl
 
 echo "Download cfssljson ..."
-curl -o /usr/sbin/cfssljson -SL https://github.com/osixia/cfssl/releases/download/1.3.4/cfssljson_linux-amd64
+echo "curl -o /usr/sbin/cfssljson -SL https://github.com/osixia/cfssl/releases/download/1.3.4/cfssljson_linux-${HOST_ARCH}"
+eval curl -o /usr/sbin/cfssljson -SL https://github.com/osixia/cfssl/releases/download/1.3.4/cfssljson_linux-"${HOST_ARCH}"
 chmod 700 /usr/sbin/cfssljson
 
 echo "Project sources: https://github.com/cloudflare/cfssl"

--- a/image/service-available/:ssl-tools/download.sh
+++ b/image/service-available/:ssl-tools/download.sh
@@ -31,12 +31,10 @@ to_install=()
 
 if [ "$(dpkg-query -W -f='${Status}' curl 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
     to_install+=("curl")
-    echo "Installing curl."
 fi
 
 if [ "$(dpkg-query -W -f='${Status}' ca-certificates 2>/dev/null | grep -c "ok installed")" -eq 0 ]; then
     to_install+=("ca-certificates")
-    echo "Installing ca-certificates."
 fi
 
 if [ ${#to_install[@]} -ne 0 ]; then
@@ -44,6 +42,11 @@ if [ ${#to_install[@]} -ne 0 ]; then
 fi
 
 LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssl jq
+
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=923479
+if [[ "${HOST_ARCH}" == 'arm' ]]; then
+    LC_ALL=C DEBIAN_FRONTEND=noninteractive c_rehash
+fi
 
 echo "Download cfssl ..."
 echo "curl -o /usr/sbin/cfssl -SL https://github.com/osixia/cfssl/releases/download/1.3.4/cfssl_linux-${HOST_ARCH}"


### PR DESCRIPTION
This pull request implements:
* A new way of downloading the correct binary for each architecture for the cfssl library 
* Improving the the travis.yml. In the previous approach the UT were run in a after_success step (https://docs.travis-ci.com/user/job-lifecycle/#breaking-the-build). That step will NOT mark the build as failed if the UT fail. Moreover the deploy procedure is trigger now only in the case that the commits are coming from the osixia/docker-light-baseimage repo.

OLD Description:
While trying to make the docker-openldap a multi arch image, I realised that we were downloading a x86_64 binary that was not running on the aarch machines (e.g. raspberry). 
So this pull request implements a suggestion to solve this limitation.

With this pull request the source code of the cfssl library is being downloaded and compiled as a prebuild step. Then the produced binaries are included in the final image. (Currently I am using the official repo to download the source code, but that can be changed. I did not see any changes in the osixia repo, and I guessed that it is there only for creating and releasing the binaries).

Furthermore, I improved a little bit the travis.yml. In the previous approach the UT were run in a after_success step (https://docs.travis-ci.com/user/job-lifecycle/#breaking-the-build). That step will NOT mark the build as failed if the UT fail. Moreover the deploy procedure is trigger now only in the case that the commits are coming from the osixia/docker-light-baseimage repo.

I hope it is useful.
If something is not clear (or wrong), please let me know and I will try to explain it (fix it) :)