### PR TITLE
allow usage of additional hostnames in self signed certificate

### DIFF
--- a/image/service-available/:ssl-tools/assets/tool/cfssl-helper
+++ b/image/service-available/:ssl-tools/assets/tool/cfssl-helper
@@ -170,6 +170,11 @@ if [ ! -e "$CERT_FILE" ] && [ ! -e "$KEY_FILE" ]; then
       CONFIG_PARAM="-config $CONFIG_FILE"
   fi
 
+  if [ -n "$ADDITIONAL_HOSTNAMES" ]; then
+    log-helper debug "additional hostnames found"
+    CFSSL_HOSTNAME="${CFSSL_HOSTNAME},${ADDITIONAL_HOSTNAMES}"
+  fi
+
   [[ -n "$CFSSL_HOSTNAME" ]] && HOSTNAME_PARAM="-hostname $CFSSL_HOSTNAME"
   [[ -n "$CFSSL_PROFILE" ]] && PROFILE_PARAM="-profile $CFSSL_PROFILE"
   [[ -n "$CFSSL_LABEL" ]] && LABEL_PARAM="-label $CFSSL_LABEL"


### PR DESCRIPTION
controlled by env var ADDITIONAL_HOSTNAMES
should be comma separated list as per cfssl documentation

My use case is relatively simple explained. I'm using your openldap image in kubernetes and I'd like to be able have replication between masters encrypted as well as encrypted traffic through the service load balancing.

For this to work I need to be able to setup additional Hostnames for the generated certificates. I'm already using this change by simply injecting the modified script through a configmap without any problems.