### PR TITLE
Fix ARM builds e.g. for keepalived

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,10 @@ before_script:
   # In native builds this information and binaries are not necessary and that is why
   # we are injecting them in the build scripts and we do not include them in the Dockerfiles
   - if [[ "${TARGET_ARCH}" != 'amd64' ]]; then
-    sed -i "s/FROM debian/FROM ${TARGET_ARCH}\/debian/" image/Dockerfile;
+    sed -i "s/FROM alpine/FROM ${TARGET_ARCH}\/alpine/" image/Dockerfile;
     fi
   - if [[ "${TARGET_ARCH}" != 'amd64' ]]; then
-    sed -i "/${TARGET_ARCH}\/debian/a COPY \
+    sed -i "/${TARGET_ARCH}\/alpine/a COPY \
     --from=multiarch/qemu-user-static:x86_64-${QEMU_ARCH} \
     /usr/bin/qemu-${QEMU_ARCH}-static /usr/bin/" image/Dockerfile;
     fi


### PR DESCRIPTION
Hi,

while checking these issues about osixia/keepalived not working on ARM machines I found out, that the base image also is not running on ARM - this meant that already this container build was broken.

Fixes https://github.com/osixia/docker-keepalived/issues/35, fixes https://github.com/osixia/docker-keepalived/issues/42

I verified everything for this image by building it into https://hub.docker.com/repository/docker/linkvt/osixia_light-baseimage 

I then also used this image in a github actions build of the keepalived container and it also started successfully: https://hub.docker.com/repository/docker/linkvt/osixia_keepalived 

BR, Vincent