### PR TITLE
Upgrade to debian bookworm

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 COPY . /container
 RUN /container/build.sh

--- a/image/service-available/:ssl-tools/download.sh
+++ b/image/service-available/:ssl-tools/download.sh
@@ -52,13 +52,13 @@ if [[ "${HOST_ARCH}" == 'arm' ]]; then
 fi
 
 echo "Download cfssl ..."
-echo "curl -o /usr/sbin/cfssl -SL https://github.com/osixia/cfssl/releases/download/1.5.0/cfssl_linux-${HOST_ARCH}"
-curl -o /usr/sbin/cfssl -SL "https://github.com/osixia/cfssl/releases/download/1.5.0/cfssl_linux-${HOST_ARCH}"
+echo "curl -o /usr/sbin/cfssl -SL https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssl_1.6.4_linux_${HOST_ARCH}"
+curl -o /usr/sbin/cfssl -SL "https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssl_1.6.4_linux_${HOST_ARCH}"
 chmod 700 /usr/sbin/cfssl
 
 echo "Download cfssljson ..."
-echo "curl -o /usr/sbin/cfssljson -SL https://github.com/osixia/cfssl/releases/download/1.5.0/cfssljson_linux-${HOST_ARCH}"
-curl -o /usr/sbin/cfssljson -SL "https://github.com/osixia/cfssl/releases/download/1.5.0/cfssljson_linux-${HOST_ARCH}"
+echo "curl -o /usr/sbin/cfssljson -SL https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssljson_1.6.4_linux_${HOST_ARCH}"
+curl -o /usr/sbin/cfssljson -SL "https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssljson_1.6.4_linux_${HOST_ARCH}"
 chmod 700 /usr/sbin/cfssljson
 
 echo "Project sources: https://github.com/cloudflare/cfssl"

--- a/image/tool/run
+++ b/image/tool/run
@@ -297,7 +297,7 @@ def import_env_files():
 						debug("process environment file : " + filepath)
 
 						if file.endswith(ENV_FILES_YAML_EXTENSIONS):
-							env_vars = yaml.load(f)
+							env_vars = yaml.load(f, Loader=yaml.FullLoader)
 
 						elif file.endswith(ENV_FILES_JSON_EXTENSIONS):
 							env_vars = json.load(f)


### PR DESCRIPTION
Image updated to debian:bookworm-slim.
SSL-Tools updated to use the latest versions
The `yaml.load` call updated to use the yaml.FullLoader (required by latest pyyaml updates I guess).

Issue: https://github.com/osixia/docker-light-baseimage/issues/33